### PR TITLE
fix undefined reference to `CLSID_SpVoice' build missing sapi library on windows

### DIFF
--- a/platform/windows/meson.build
+++ b/platform/windows/meson.build
@@ -68,6 +68,7 @@ if PLATFORM == 'windows'
         _cpp.find_library('wbemuuid'),
         _cpp.find_library('dbghelp'),
         _cpp.find_library('crypt32'),
+        _cpp.find_library('sapi'),        
 ]
 
     CPP_ARGS += [


### PR DESCRIPTION
fix undefined reference to `CLSID_SpVoice' build missing sapi library on windows