### PR TITLE
fix Escape Character  error in cpp when generate the head file on windows 

### DIFF
--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -13,6 +13,7 @@ import tempfile
 import uuid
 import zlib
 
+from pathlib import Path
 
 from glob import glob
 
@@ -74,7 +75,7 @@ def make_doc_header(compr_filename, modules):
         g.write("struct _DocDataClassPath { const char* name; const char* path; };\n")
         g.write(f"static const _DocDataClassPath _doc_data_class_paths[{len(path_entries)+1}] = {{\n")
         for i in path_entries:
-            g.write(f'        {{"{i[0]}", "{i[1]}"}},\n')
+            g.write(f'        {{"{i[0]}", "{Path(i[1]).as_posix()}"}},\n')
         g.write("        {nullptr, nullptr}\n};")
     replace_if_different(path_filename, path_tmpname)
 

--- a/platform/windows/meson.build
+++ b/platform/windows/meson.build
@@ -68,6 +68,7 @@ if PLATFORM == 'windows'
         _cpp.find_library('wbemuuid'),
         _cpp.find_library('dbghelp'),
         _cpp.find_library('crypt32'),
+        _cpp.find_library('sapi'),        
 ]
 
     CPP_ARGS += [


### PR DESCRIPTION
fix Escape Character  error in cpp when generate the head file on windows

use meson generate the header file on window:
![image](https://github.com/jpakkane/godot/assets/25509024/f083021e-ff2e-4f62-b968-101585e4b294)
use scons generate godot header file on windows  :
![image](https://github.com/jpakkane/godot/assets/25509024/724cfdd6-c637-4f82-bd8f-4c1ea7005559)

